### PR TITLE
Add missing lxd step required to publish charm

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -179,6 +179,8 @@ jobs:
     needs: [ get-images, get-run-id, get-runner-image]
     if: ${{ needs.get-images.outputs.images != '[]' }}
     steps:
+      - uses: canonical/setup-lxd@v0.1.1
+
       - uses: actions/checkout@v4
         if: env.charmcraft_repository != ''
         with:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to NetBox Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->
Add missing lxd step required to publish charm in publish_charm.yaml


### Rationale

<!-- The reason the change is needed -->
Required to publish the charm.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
