### PR TITLE
Fix django-debug env variable

### DIFF
--- a/netbox/netbox/configuration.py
+++ b/netbox/netbox/configuration.py
@@ -138,7 +138,7 @@ CSRF_COOKIE_NAME = 'csrftoken'
 # Set to True to enable server debugging. WARNING: Debugging introduces a substantial performance penalty and may reveal
 # sensitive information about your installation. Only enable debugging while performing testing. Never enable debugging
 # on a production system.
-DEBUG = os.environ.get("DJANGO_DEBUG", False)
+DEBUG = os.environ.get("DJANGO_DEBUG", "false") == "true"
 
 # Set the default preferred language/locale
 DEFAULT_LANGUAGE = 'en-us'


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to NetBox Operator!
Please, provide some information about your PR before proceeding.
-->

<!-- Applicable spec: <link> -->

### Overview

<!-- A high level overview of the change -->

DEBUG Django configuration is always True, as it should be a bool and not a string.

Just when the env variable DJANGO_DEBUG is "true", put DEBUG to True, otherwise DEBUG should be False.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
