### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NetBox Operator
 
-This repository contains Netbox plus a Juju charm for deploying and managing NetBox on Kubernetes. See [charm README](./charm/README.md) for more information.
+This repository contains NetBox plus a Juju charm for deploying and managing NetBox on Kubernetes. See [charm README](./charm/README.md) for more information.
 
-For the original Netbox repository, see https://github.com/netbox-community/netbox/
+For the original NetBox repository, see https://github.com/netbox-community/netbox/
 
 # NetBox
 

--- a/charm/docs/explanation/charm-architecture.md
+++ b/charm/docs/explanation/charm-architecture.md
@@ -1,4 +1,4 @@
-# NetBox charm architecture
+# Charm architecture
 
 The NetBox charm initial version has been generated with the help of
 the [paas-app-charmer](https://github.com/canonical/paas-app-charmer/)

--- a/charm/docs/how-to/contribute.md
+++ b/charm/docs/how-to/contribute.md
@@ -86,7 +86,7 @@ juju deploy ./charm/netbox_ubuntu-22.04-amd64.charm \
   --resource django-app-image=localhost:32000/netbox:latest
 ```
 
-### Configure NetBox
+### Configure
 
 NetBox requires a Redis integration to work correctly. This can be
 done with:

--- a/charm/docs/index.md
+++ b/charm/docs/index.md
@@ -36,7 +36,7 @@ for more information.
 
 ## Other resources
 
-* [Netbox upstream repository](https://github.com/netbox-community/netbox)
+* [NetBox upstream repository](https://github.com/netbox-community/netbox)
 * [Get support](https://discourse.charmhub.io/)
 * [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 * [Contribute](https://charmhub.io/netbox/docs/contributing)
@@ -62,7 +62,7 @@ missing, please [file a bug](https://github.com/canonical/netbox/issues).
 
 1. [Tutorial](tutorial)
   1. [Getting Started](tutorial/getting-started.md)
-  1. [Testing Netbox](tutorial/testing-netbox.md)
+  1. [Testing NetBox](tutorial/testing-netbox.md)
 1. [How To](how-to)
   1. [Contribute](how-to/contribute.md)
   2. [Configure SAML](how-to/configure-saml.md)

--- a/charm/docs/tutorial/getting-started.md
+++ b/charm/docs/tutorial/getting-started.md
@@ -13,7 +13,7 @@ your NetBox instance.
 
 ## Requirements
 - Juju 3.x installed.
-- Juju controller that can create a model of type kubernetes.
+- Juju controller that can create a model of type Kubernetes.
 - Read/write access to a S3 compatible server with a bucket created.
 - Configuration compatible with the traefik-k8s charms. In the case of MicroK8s this can be achieved with the `metallb` add-on.
 
@@ -29,11 +29,10 @@ your usual work, we recommend creating a new model using the following command.
 juju add-model netbox-tutorial
 ```
 
-## Deploy the NetBox charm
+## Deploy
 
 Deploy the NetBox charm, with all its mandatory requirements (PostgreSQL, Redis and S3).
 
-### Deploy the charms:
 ```
 juju deploy netbox
 ```

--- a/charm/docs/tutorial/testing-netbox.md
+++ b/charm/docs/tutorial/testing-netbox.md
@@ -1,4 +1,6 @@
-# Testing NetBox
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Test NetBox
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 We recommend the [Getting Started Tutorial](./getting-started.md) to get familiarised with NetBox in a Juju deployment.
 
@@ -21,7 +23,9 @@ as the NetBox charm is only built for amd64.
 
 Follow the instruction in [https://multipass.run/install](https://multipass.run/install).
 
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
 ## Launch NetBox with a Multipass VM
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 You will launch a VM named `netbox` with Multipass, using the
 [cloud init configuration](https://raw.githubusercontent.com/canonical/netbox/main/charm/cloudinit-juju-3.1.yaml)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to NetBox Operator!
Please, provide some information about your PR before proceeding.
-->

Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
There are no `src` docs.
Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR.