### PR TITLE
Point Vale checks to correct directories

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,3 +11,4 @@ jobs:
       charm-directory: "charm"
       shellcheck-working-directory: "./charm"
       vale-style-check: true
+      vale-files: '["charm/docs/**/*.md", "README.md"]' 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+
 # NetBox Operator
 
 This repository contains NetBox plus a Juju charm for deploying and managing NetBox on Kubernetes. See [charm README](./charm/README.md) for more information.


### PR DESCRIPTION
### Overview

Point Vale checks to correct directories.

### Rationale

This repository contains upstream documentation that throws a lot of errors with the Vale style checker. By configuring the checks to point to the charm documentation and README only, the style checks should be more successful and useful. 

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Manging Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No documentation changes in this PR. There are no src docs